### PR TITLE
Created spec util to handle common api request and response config and assertions

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -1,33 +1,31 @@
 package com.api.tests;
 
-import static org.hamcrest.Matchers.*;
+import static com.api.constants.Role.FD;
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.testng.annotations.Test;
 
-import static com.api.constants.Role.*;
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
-
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
-
-import static io.restassured.RestAssured.*;
+import com.api.utils.SpecUtil;
 
 public class CountAPITest {
 	
 	@Test
 	public void verifyCountAPIResponse()
 	{
-		given().baseUri(getProperty("BASE_URI"))
-		.and()
-		.header("Authorization", getToken(FD))
-		.and()
-		.log().uri()
-		.log().method()
-		.log().headers()
+		given()
+		.spec(SpecUtil.RequestSpecWithAuth(FD))
 		.when()
 		.get("/dashboard/count")
-		.then().log().all()
-		.and().statusCode(200)
-		.time(lessThanOrEqualTo(1500L))
+		.then()
+		.spec(SpecUtil.ResponseSpec_JSON(200))
 		.body("message", equalTo("Success"))
 		.body("data", notNullValue())
 		.body("data.size()", equalTo(3))
@@ -40,15 +38,12 @@ public class CountAPITest {
 	@Test
 	public void countAPITest_MissingAuthToken()
 	{
-		given().baseUri(getProperty("BASE_URI"))
-		.and()
-		.log().uri()
-		.log().method()
-		.log().headers()
+		given()
+        .spec(SpecUtil.RequestSpec())
 		.when()
 		.get("/dashboard/count")
-		.then().log().all()
-		.statusCode(401);
+		.then()
+		.spec(SpecUtil.ResponseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -1,15 +1,13 @@
 package com.api.tests;
 
-import static com.api.utils.ConfigManager.getProperty;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
 
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
 import com.pojo.classes.UserCredentials;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 
@@ -20,23 +18,12 @@ public class LoginAPITest {
 	{
 		//Rest Assured Code
 		UserCredentials user = new UserCredentials("iamfd", "password");
-		given().baseUri(getProperty("BASE_URI"))
-		.and()
-		.contentType(ContentType.JSON)
-		.and()
-		.accept(ContentType.ANY)
-		.and()
-		.body(user)
-		.log().uri()
-		.log().headers()
-		.log().method()
-		.log().body()
+		given()
+		.spec(SpecUtil.RequestSpec(user))
 		.when()
 		.post("login")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(2500L))
+		.spec(SpecUtil.ResponseSpec_JSON(200))
 		.and()
 		.body("message", equalTo("Success"))
 		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/LoginResponseSchema.json"));

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -1,15 +1,18 @@
 package com.api.tests;
 
-import static org.hamcrest.Matchers.*;
+import static com.api.constants.Role.FD;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import io.restassured.module.jsv.JsonSchemaValidator;
-
-import static com.api.constants.Role.*;
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
-
-import static io.restassured.RestAssured.*;
 
 public class MasterAPITest {
 	
@@ -17,19 +20,11 @@ public class MasterAPITest {
 	public void masterAPITest()
 	{
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.header("Authorization", getToken(FD))
-		.and()
-		.contentType("")
-		.log().headers()
-		.log().uri()
-		.log().method()
+		.spec(SpecUtil.RequestSpecWithAuth(FD))
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(200)
+		.spec(SpecUtil.ResponseSpec_JSON(200))
 		.body("message", equalTo("Success"))
 		.body("data", notNullValue())
 		.body("$", hasKey("data"))
@@ -48,19 +43,11 @@ public class MasterAPITest {
 	public void invalidTokenTest()
 	{
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.header("Authorization", "")
-		.and()
-		.contentType("")
-		.log().headers()
-		.log().uri()
-		.log().method()
+		.spec(SpecUtil.RequestSpec())
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.ResponseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -1,18 +1,13 @@
 package com.api.tests;
 
-import static com.api.utils.ConfigManager.getProperty;
+import static com.api.constants.Role.FD;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
 
 import org.testng.annotations.Test;
 
-import static com.api.constants.Role.*;
+import com.api.utils.SpecUtil;
 
-import static com.api.utils.AuthTokenProvider.*;
-
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class UserDetailsAPITest {
@@ -22,23 +17,13 @@ public class UserDetailsAPITest {
 	{
 		//System.out.println("asd");
 		//System.out.println(getToken("fd"));
-		Header auth = new Header("Authorization", getToken(FD));
+		//Header auth = new Header("Authorization", getToken(FD));
 		
-		 given().baseUri(getProperty("BASE_URI"))
-		 .and()
-		 .header(auth)
-		 .and()
-		 .accept(ContentType.ANY)
-		 .log().uri()
-		 .log().headers()
-		 .log().method()
-		 .log().body()
+		 given().spec(SpecUtil.RequestSpecWithAuth(FD))
 		 .when()
 		 .get("userdetails")
 		 .then()
-		 .statusCode(200)
-		 .log().all()
-		 .time(lessThan(1000L))
+		 .spec(SpecUtil.ResponseSpec_JSON(200))
 		 .and()
 		 .body("message", equalTo("Success"))
 		 .and()

--- a/src/test/java/com/api/utils/AuthTokenProvider.java
+++ b/src/test/java/com/api/utils/AuthTokenProvider.java
@@ -1,15 +1,13 @@
 package com.api.utils;
 
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
 import com.api.constants.Role;
 import com.pojo.classes.UserCredentials;
 
 import io.restassured.http.ContentType;
-
-import static io.restassured.RestAssured.*;
-
-import static org.hamcrest.Matchers.*;
-
-import org.testng.annotations.Test;
 
 public class AuthTokenProvider {
 	

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,66 @@
+package com.api.utils;
+
+import static com.api.utils.ConfigManager.getProperty;
+
+import org.hamcrest.Matchers;
+
+import com.api.constants.Role;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+
+	//GET and DEl
+	public static RequestSpecification RequestSpec() {
+		RequestSpecification spec = new RequestSpecBuilder().setBaseUri(getProperty("BASE_URI")).
+		setContentType(ContentType.JSON).setAccept(ContentType.JSON)
+		.log(LogDetail.URI).log(LogDetail.METHOD).log(LogDetail.HEADERS)
+		.log(LogDetail.BODY).build();
+		
+		return spec;
+
+	}
+	
+	public static RequestSpecification RequestSpecWithAuth(Role role) {
+		RequestSpecification spec = new RequestSpecBuilder().setBaseUri(getProperty("BASE_URI"))
+		.addHeader("Authorization", AuthTokenProvider.getToken(role)).
+		setContentType(ContentType.JSON).setAccept(ContentType.JSON)
+		.log(LogDetail.URI).log(LogDetail.METHOD).log(LogDetail.HEADERS)
+		.log(LogDetail.BODY).build();
+		
+		return spec;
+
+	}
+	
+	//POST & PUT
+	public static RequestSpecification RequestSpec(Object payload) {
+		RequestSpecification spec = new RequestSpecBuilder().setBaseUri(getProperty("BASE_URI")).
+		setContentType(ContentType.JSON).setAccept(ContentType.JSON)
+		.log(LogDetail.URI).log(LogDetail.METHOD).log(LogDetail.HEADERS)
+		.log(LogDetail.BODY).setBody(payload).build();
+		
+		return spec;
+
+	}
+	
+	public static ResponseSpecification ResponseSpec_JSON(int status)
+	{
+		ResponseSpecification respSpec = new ResponseSpecBuilder().expectStatusCode(status).
+		expectContentType(ContentType.JSON).expectResponseTime(Matchers.lessThan(1500L))
+		.log(LogDetail.ALL).build();
+		return respSpec;
+	}
+	public static ResponseSpecification ResponseSpec_TEXT(int status)
+	{
+		ResponseSpecification respSpec = new ResponseSpecBuilder().expectStatusCode(status).
+		expectResponseTime(Matchers.lessThan(1500L))
+		.log(LogDetail.ALL).build();
+		return respSpec;
+	}
+
+}


### PR DESCRIPTION
SpecUtils consists of common RequestSpecBuilder and ResponseSpecBuilder. The utils has reduced the boiler plate code in our api tests and also reduced the number of lines, making it smaller and maintainable.